### PR TITLE
Add placeholder visuals for board tiles and units

### DIFF
--- a/scenes/Unit.tscn
+++ b/scenes/Unit.tscn
@@ -5,14 +5,13 @@
 [node name="Unit" type="Node2D"]
 script = ExtResource("1")
 
-[node name="Body" type="ColorRect" parent="."]
-position = Vector2(-24, -24)
-size = Vector2(48, 48)
-color = Color(0.6, 0.6, 0.6, 1)
+[node name="Sprite" type="Sprite2D" parent="."]
+position = Vector2(0, 0)
+centered = true
 
 [node name="Label" type="Label" parent="."]
-position = Vector2(-32, 28)
-size = Vector2(64, 24)
+position = Vector2(-32, 24)
+size = Vector2(64, 32)
 text = "Unit"
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/scripts/board.gd
+++ b/scripts/board.gd
@@ -17,10 +17,14 @@ var attack_color := Color(1.0, 0.2, 0.2, 0.35)
 var enemy_range_color := Color(0.75, 0.3, 1.0, 0.25)
 var selection_outline := Color(1.0, 0.9, 0.2, 0.9)
 
+var tile_texture_dark: Texture2D
+var tile_texture_light: Texture2D
+
 func setup(size: Vector2i, new_tile_size: int) -> void:
     grid_width = size.x
     grid_height = size.y
     tile_size = new_tile_size
+    _generate_tile_textures()
     update()
 
 func clear_highlights() -> void:
@@ -43,8 +47,13 @@ func _draw() -> void:
     for x in range(grid_width):
         for y in range(grid_height):
             var tile_position := Vector2(x * tile_size, y * tile_size)
-            var color := background_color_dark if ((x + y) % 2 == 0) else background_color_light
-            draw_rect(Rect2(tile_position, Vector2(tile_size, tile_size)), color)
+            var rect := Rect2(tile_position, Vector2(tile_size, tile_size))
+            var texture := tile_texture_dark if ((x + y) % 2 == 0) else tile_texture_light
+            if texture:
+                draw_texture_rect(texture, rect, false)
+            else:
+                var color := background_color_dark if ((x + y) % 2 == 0) else background_color_light
+                draw_rect(rect, color)
 
     for tile in enemy_range_tiles:
         if is_inside(tile):
@@ -76,3 +85,27 @@ func world_to_map(point: Vector2) -> Vector2i:
 
 func is_inside(tile: Vector2i) -> bool:
     return tile.x >= 0 and tile.y >= 0 and tile.x < grid_width and tile.y < grid_height
+
+func _generate_tile_textures() -> void:
+    tile_texture_dark = _create_tile_texture(background_color_dark)
+    tile_texture_light = _create_tile_texture(background_color_light)
+
+func _create_tile_texture(base_color: Color) -> Texture2D:
+    if tile_size <= 0:
+        return null
+    var image := Image.create(tile_size, tile_size, false, Image.FORMAT_RGBA8)
+    image.lock()
+    var border_thickness := max(int(tile_size / 16), 2)
+    var accent_step := max(int(tile_size / 8), 4)
+    var accent_color := base_color.lightened(0.08)
+    var border_color := base_color.darkened(0.25)
+    for x in range(tile_size):
+        for y in range(tile_size):
+            var color := base_color
+            if x < border_thickness or y < border_thickness or x >= tile_size - border_thickness or y >= tile_size - border_thickness:
+                color = border_color
+            elif int(x / accent_step + y / accent_step) % 2 == 0:
+                color = accent_color
+            image.set_pixel(x, y, color)
+    image.unlock()
+    return ImageTexture.create_from_image(image)

--- a/scripts/unit.gd
+++ b/scripts/unit.gd
@@ -13,7 +13,7 @@ var has_acted: bool = false
 var grid_position: Vector2i = Vector2i.ZERO
 var board: Board
 
-@onready var body: ColorRect = $Body
+@onready var sprite: Sprite2D = $Sprite
 @onready var label: Label = $Label
 
 const CLASS_COLORS := {
@@ -26,6 +26,8 @@ const TEAM_TINTS := {
     "player": Color(0.25, 0.45, 0.95),
     "enemy": Color(0.95, 0.35, 0.35),
 }
+
+var _texture_cache := {}
 
 func _ready() -> void:
     update_visual()
@@ -49,14 +51,23 @@ func set_grid_position(tile: Vector2i) -> void:
         position = board.map_to_world(tile)
 
 func update_visual() -> void:
-    if not body or not label:
+    if not sprite or not label:
         return
     var base_color := CLASS_COLORS.get(class_name, Color(0.8, 0.8, 0.8))
     var team_tint := TEAM_TINTS.get(team, Color(1, 1, 1))
-    body.color = base_color.lerp(team_tint, 0.35)
+    var final_color := base_color.lerp(team_tint, 0.35)
+    var tile_pixels := _get_tile_visual_size()
+    sprite.texture = _get_placeholder_texture(tile_pixels, final_color)
+    sprite.scale = Vector2.ONE
+    sprite.position = Vector2.ZERO
+    sprite.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
     label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
     label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+    label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
     label.text = "%s\nHP: %d" % [unit_name, hp]
+    var label_width := float(tile_pixels)
+    label.custom_minimum_size = Vector2(label_width, 36)
+    label.position = Vector2(-label_width * 0.5, tile_pixels * 0.35)
 
 func take_damage(amount: int) -> void:
     hp = max(hp - amount, 0)
@@ -64,3 +75,35 @@ func take_damage(amount: int) -> void:
 
 func is_alive() -> bool:
     return hp > 0
+
+func _get_tile_visual_size() -> int:
+    var size := 56
+    if board and board.tile_size > 0:
+        size = max(board.tile_size - 8, 32)
+    return size
+
+func _get_placeholder_texture(size: int, fill_color: Color) -> Texture2D:
+    var key := "%d_%s" % [size, fill_color.to_html(false)]
+    if _texture_cache.has(key):
+        return _texture_cache[key]
+    var image := Image.create(size, size, false, Image.FORMAT_RGBA8)
+    image.lock()
+    var outline := max(int(size * 0.08), 2)
+    var accent := max(int(size * 0.12), 3)
+    var edge_color := fill_color.darkened(0.3)
+    var accent_color := fill_color.lightened(0.18)
+    for x in range(size):
+        for y in range(size):
+            var color := fill_color
+            if x < outline or y < outline or x >= size - outline or y >= size - outline:
+                color = edge_color
+            elif abs(x - size / 2) <= accent and abs(y - size / 2) <= 1:
+                color = accent_color
+            elif abs(y - size / 2) <= accent and abs(x - size / 2) <= 1:
+                color = accent_color
+            image.set_pixel(x, y, color)
+    image.unlock()
+    var texture := ImageTexture.create_from_image(image)
+    texture.set_path("")
+    _texture_cache[key] = texture
+    return texture


### PR DESCRIPTION
## Summary
- generate reusable textured placeholder tiles for the board and use them when drawing the grid
- refresh the unit scene to render sprite-based placeholder characters tinted by class and team colors
- adjust unit labels to follow the new placeholder art sizing

## Testing
- ⚠️ `godot4 --headless --path . --quit` *(command unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19098665483328786c6f0f8678191